### PR TITLE
fix(planning-import): add planning types and wire PDF import component

### DIFF
--- a/src/types/planning.d.ts
+++ b/src/types/planning.d.ts
@@ -1,0 +1,15 @@
+export type CourseData = {
+  id: string;
+  day?: string;
+  time?: string;
+  startTime?: string;
+  endTime?: string;
+  subject: string;
+  teacher?: string;
+  room?: string;
+};
+
+export type ParsedSchedule = {
+  totalCourses: number;
+  courses: CourseData[];
+};


### PR DESCRIPTION
- Add src/types/planning.d.ts with CourseData and ParsedSchedule
- Implement AFP regex parsing in src/lib/pdf-parser.ts with fallback
- Add SmartPlanningIntelligent component for PDF import, rendering, and localStorage

Do not merge yet — awaiting validation on browsers and AFP samples.